### PR TITLE
docs: Update README for latest tagged release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ services/writerServices.go
 ## Example Usage
 
 ```yaml
-uses: Jerome1337/gofmt-action@v1.0.2
+uses: Jerome1337/gofmt-action@v1.0.4
 with:
   gofmt-path: './src'
   gofmt-flags: '-l -d'


### PR DESCRIPTION
The example usage section was updated to use a `gofmt-flags` parameter that is only available with the latest tagged release. This commit updates the example to use that release tag for the `uses` configuration.